### PR TITLE
added actions for handling sub documents

### DIFF
--- a/src/barrage_action_kvs.erl
+++ b/src/barrage_action_kvs.erl
@@ -28,6 +28,7 @@
 
 %% API
 -export([load/3]).
+-export([load_array/3]).
 -export([read_random/4]).
 -export([read_name/4]).
 -export([store_key/4]).
@@ -55,6 +56,16 @@ load(Profile, File, State) ->
     {KVS}       = jiffy:decode(KVSRaw),
     KVSStore    = dict:from_list(KVS),
     StateKVS    = dict:store(Profile, KVSStore, State#state.keystore),
+    State#state{keystore = StateKVS}.
+
+
+load_array(Profile, File, State) ->
+    BasePath    = code:priv_dir(barrage),
+    LFile       = binary_to_list(File),
+    Path        = BasePath ++ "/" ++ LFile,
+    {ok, KVSRaw}= file:read_file(Path), 
+    ArrayStore  = jiffy:decode(KVSRaw),
+    StateKVS    = dict:store(Profile, ArrayStore, State#state.keystore),
     State#state{keystore = StateKVS}.
 
 read_random(Profile, KeyStorageName, ValueStorageName, State) ->

--- a/src/barrage_gunner.erl
+++ b/src/barrage_gunner.erl
@@ -432,6 +432,27 @@ do_action(<<"read_random_kv">>, {Args}, _Children, State) ->
     Value   = proplists:get_value(<<"value">>, Args),
     barrage_action_kvs:read_random(Profile, Key, Value, State);  
 
+
+%%%%------------------------------------------------------------------
+%%%% Action: <<"read_random_number">>
+%%%%------------------------------------------------------------------
+do_action(<<"read_random_value">>, undefined, _Children, State) ->
+    State;
+
+do_action(<<"read_random_value">>, {Args}, _Children, State) ->
+    Min     = proplists:get_value(<<"min">>, Args),
+    Max     = proplists:get_value(<<"max">>, Args),
+    Preffix = proplists:get_value(<<"preffix">>, Args),
+    NumberKey  = proplists:get_value(<<"number">>, Args),
+    NameKey    = proplists:get_value(<<"name">>, Args),
+    
+    Number  = Min + random:uniform(Max - Min),
+    BinNumber = integer_to_binary(Number),
+    Name    = <<Preffix/binary, BinNumber/binary>>, 
+    NewDic  = dict:store(NumberKey, Number, State#state.keystore),
+    UpdatedDic  = dict:store(NameKey, Name, NewDic),    
+    State#state{keystore = UpdatedDic};
+
 %%%%------------------------------------------------------------------
 %%%% Action: <<"read_named_kv">>
 %%%%------------------------------------------------------------------
@@ -535,7 +556,6 @@ do_action(<<"read_sequential_array_idx">>, {Args}, _Children, State) ->
                 {ok, FoundValue} -> FoundValue;
                 error -> 0
              end,
-
     {ok, Array} = dict:find(Key, State#state.keystore),
     case length(Array) of 
         0 ->

--- a/src/barrage_gunner.erl
+++ b/src/barrage_gunner.erl
@@ -454,8 +454,6 @@ do_action(<<"read_array_idx">>, {Args}, _Children, State) ->
     Key         = proplists:get_value(<<"key">>, Args),
     Idx         = proplists:get_value(<<"idx">>, Args),
     Variable    = proplists:get_value(<<"variable">>, Args),
-
-   %% NewKey      = get_stored_value(Key, State),
     NewIdx      = get_stored_value(Idx, State),
     {ok, Array} = dict:find( Key, State#state.keystore),
     case is_binary(NewIdx) of
@@ -470,6 +468,39 @@ do_action(<<"read_array_idx">>, {Args}, _Children, State) ->
                 true ->
                     IIdx= list_to_integer(NewIdx), 
                     NewData     = lists:nth(IIdx, Array),
+                    NewDic      = dict:store(Variable, NewData, State#state.keystore),
+                    State#state{keystore = NewDic};
+                false ->
+                    NewData     = lists:nth(NewIdx, Array),
+                    NewDic      = dict:store(Variable, NewData, State#state.keystore),
+                    State#state{keystore = NewDic}
+            end
+    end;
+
+%%%%------------------------------------------------------------------
+%%%% Action: <<"read_array_idx">>
+%%%%------------------------------------------------------------------
+do_action(<<"read_doc_set_idx">>, undefined, _Children, State) ->
+    State;
+
+do_action(<<"read_doc_set_idx">>, {Args}, _Children, State) ->
+    Key         = proplists:get_value(<<"key">>, Args),
+    Idx         = proplists:get_value(<<"idx">>, Args),
+    Variable    = proplists:get_value(<<"variable">>, Args),
+    NewIdx      = get_stored_value(Idx, State),
+    {ok, {Array}} = dict:find( Key, State#state.keystore),
+    case is_binary(NewIdx) of
+        true ->
+            LIdx= binary_to_list(NewIdx),
+            IIdx= list_to_integer(LIdx),
+            {_,NewData} = lists:nth(IIdx, Array),
+            NewDic      = dict:store(Variable, NewData, State#state.keystore),
+            State#state{keystore = NewDic};
+        false ->
+            case is_list(NewIdx) of
+                true ->
+                    IIdx= list_to_integer(NewIdx), 
+                    {_,NewData} = lists:nth(IIdx, Array),
                     NewDic      = dict:store(Variable, NewData, State#state.keystore),
                     State#state{keystore = NewDic};
                 false ->
@@ -498,6 +529,27 @@ do_action(<<"read_random_array_idx">>, {Args}, _Children, State) ->
             NewDic      = dict:store(Variable, NewData, State#state.keystore),
             State#state{keystore = NewDic}
     end;
+
+%%%%------------------------------------------------------------------
+%%%% Action: <<"read_random_array_idx">>
+%%%%------------------------------------------------------------------
+do_action(<<"read_random_doc_set_idx">>, undefined, _Children, State) ->
+    State;
+do_action(<<"read_random_doc_set_idx">>, {Args}, _Children, State) ->
+    Key           = proplists:get_value(<<"key">>, Args),
+    Variable      = proplists:get_value(<<"variable">>, Args),
+
+    {ok, {Array}} = dict:find(Key, State#state.keystore),
+    case length(Array) of 
+        0 ->
+            State;
+        Len ->
+            Idx          = random:uniform(Len),
+            {_, NewData} = lists:nth(Idx, Array),
+            NewDic       = dict:store(Variable, NewData, State#state.keystore),
+            State#state{keystore = NewDic}
+    end;
+
 
 %%%%------------------------------------------------------------------
 %%%% Action: <<"conditional">>


### PR DESCRIPTION
I created read_doc_set_idx and and read_random_doc_set_idx to able to read and choose subdocuments:
Example: 

rewards: {
    "5194189570f9688d4d00025c" : {
            "id" : "5194189570f9688d4d00025c",
            "definitionId" : "721101",
            "from" : 13,
            "rewardType" : 3,
            "amount" : 1,
            "storeTime" : 1368660117749
        },
        "5194189570f9688d4d00025d" : {
            "id" : "5194189570f9688d4d00025d",
            "definitionId" : "720001",
            "from" : 13,
            "rewardType" : 5,
            "amount" : 1,
            "storeTime" : 1368660117749
        }
}
